### PR TITLE
Remove MIXU' keymap

### DIFF
--- a/src/config/.nbattrs
+++ b/src/config/.nbattrs
@@ -17,7 +17,4 @@
     <fileobject name="Editors">
         <attr name="currentFontColorProfile" stringvalue="Dracula"/>
     </fileobject>
-    <fileobject name="Keymaps">
-        <attr name="currentKeymap" stringvalue="MIXU&apos;"/>
-    </fileobject>
 </attributes>


### PR DESCRIPTION
This causes editor not to work if MIXU keymap doesn't exist in Netbeans.
Removing these lines keeps the current keymap active.